### PR TITLE
removed pagenumber from toc

### DIFF
--- a/uiofysmaster.cls
+++ b/uiofysmaster.cls
@@ -189,7 +189,9 @@
 {
   \pagenumberingnoreset{roman}
   \pagestyle{tableofcontents}
-%   \thispagestyle{onlypagenum}
+  
+  % \thispagestyle{onlypagenum}
+  \pagenumbering{gobble}
   \oldtableofcontents
   \cleardoublepage
 }


### PR DESCRIPTION
I think I found a way to remove the roman page numbers that appeared at the Contents pages.